### PR TITLE
Reconfigure webpack bundle analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prestart": "npm run tw",
     "start": "webpack serve --mode development",
     "build": "webpack --mode production",
-    "postbuild": "npm run tailwind && cp -R ./public/* ./build"
+    "postbuild": "npm run tw && cp -R ./public/* ./build",
+    "analyzer": "webpack-bundle-analyzer ./build/stats.json"
   },
   "dependencies": {
     "@babel/core": "^7.23.9",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,5 +36,11 @@ module.exports = {
     compress: true,
     port: 8080
   },
-  plugins: [new BundleAnalyzerPlugin({ openAnalyzer: false })]
+  plugins: [
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'disabled',
+      generateStatsFile: true,
+      openAnalyzer: false
+    })
+  ]
 };


### PR DESCRIPTION
To let the `npm run build` script actually complete

(The analyzer waits for user to CTRL+C before stopping, which breaks the build process)