### PR TITLE
Feature: Nav menu can now be closed by clicking outside the nav menu

### DIFF
--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -1,13 +1,18 @@
-<aside class="activity-list">
+<aside class="activity-list" #activityList>
   <a class="act-button clickable" routerLink="/"
     ><fa-icon class="csss-logo" [icon]="csssIcon" size="2x"
   /></a>
-  <div class="act-button clickable fs-icon" [class.focused]="isFileSystemOpen()">
-    <fa-icon (click)="toggleFileSystem()" [icon]="copyIcon" size="2x" />
+  <div
+    class="act-button clickable fs-icon"
+    [class.focused]="isFileSystemOpen()"
+    (click)="toggleFileSystem()"
+    #toggleButton
+  >
+    <fa-icon [icon]="copyIcon" size="2x" />
   </div>
 </aside>
 
-<aside class="navbar" [hidden]="!isFileSystemOpen()">
+<aside class="navbar" [hidden]="!isFileSystemOpen()" #navBar>
   <header class="navbar-header">SFU CSSS</header>
   <nav>
     <ul class="navbar-list">

--- a/src/app/components/nav-bar/nav-bar.component.ts
+++ b/src/app/components/nav-bar/nav-bar.component.ts
@@ -3,9 +3,12 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  ElementRef,
+  HostListener,
   inject,
   OnInit,
-  signal
+  signal,
+  viewChild
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MenuItemComponent } from '@csss-code/menu/menu-item/menu-item.component';
@@ -23,20 +26,49 @@ import { BREAKPOINT_STRING_MAP } from 'styles/breakpoints';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NavBarComponent implements OnInit {
+  @HostListener('document:click', ['$event'])
+  handleOutsideClick(event: MouseEvent): void {
+    if (this.breakpointObs.isMatched(BREAKPOINT_STRING_MAP['small'])) {
+      return;
+    }
+    if (
+      !this.navBarEl()?.nativeElement.contains(event.target) &&
+      !this.toggleButtonEl()?.nativeElement.contains(event.target) &&
+      !this.activityListEl()?.nativeElement.contains(event.target)
+    ) {
+      this.isFileSystemOpen.set(false);
+    }
+  }
+
+  /**
+   * Navbar/file system element
+   */
+  navBarEl = viewChild<ElementRef>('navBar');
+
+  /**
+   * Button that toggles the visibility of the navbar
+   */
+  toggleButtonEl = viewChild<ElementRef>('toggleButton');
+
+  /**
+   * The activity list bar
+   */
+  activityListEl = viewChild<ElementRef>('activityList');
+
   /**
    * Navbar entries
    */
-  entries = signal<NavbarItem[]>(NAVBAR_ENTRIES);
+  protected entries = signal<NavbarItem[]>(NAVBAR_ENTRIES);
 
   /**
    * Flag representing if the menu is closed or open.
    */
-  isFileSystemOpen = signal<boolean>(false);
+  protected isFileSystemOpen = signal<boolean>(false);
 
   /**
    * Signal that converts the nav entries, in case they need to be dynamically instantiated.
    */
-  navItems = computed(() => this.navEntryToItem(this.entries()));
+  protected navItems = computed(() => this.navEntryToItem(this.entries()));
 
   /**
    * Icon for the CSSS Logo.


### PR DESCRIPTION
Description:
The only way to close the nav menu was to use the nav menu button on the activity bar. This was okay on large screens, but on smaller screens it's a hassle. This gives our users an ergonomic way to get back to the main content.

Features:
* Clicking the outside the nav menu will close the menu