### PR TITLE
Refactor: Remove zone.js package fully from main site

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -21,7 +21,6 @@
             "outputPath": "dist/csss-ng-frontend",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -82,7 +81,6 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,8 +1,8 @@
-import { ApplicationConfig } from '@angular/core';
+import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes)]
+  providers: [provideZonelessChangeDetection(), provideRouter(routes)]
 };


### PR DESCRIPTION
Description:
Removed the `zone.js` library from the web application. This should reduce bundle size and improve the speed of the web application. The speed will not be a noticeable change.

Future issues:
There might be some bugs introduce by this change, make sure this is tested thoroughly.