### PR TITLE
Fix: Fall Hacks and Mountain Madness links were wrong

### DIFF
--- a/src/app/components/nav-bar/nav-entries.ts
+++ b/src/app/components/nav-bar/nav-entries.ts
@@ -83,13 +83,13 @@ export const NAVBAR_ENTRIES: NavItem[] = [
         key: 'events.fall-hacks',
         label: 'Fall Hacks',
         icon: faUpRightFromSquare,
-        href: 'https://new.sfucsss.org/fall_hacks/2024/index.html'
+        href: 'https://fall-hacks.sfucsss.org'
       },
       {
         key: 'events.mountain-madness',
         label: 'Mountain Madness',
         icon: faUpRightFromSquare,
-        href: 'https://new.sfucsss.org/mountain_madness/2024/index.html'
+        href: 'https://madness.sfucsss.org'
       },
       {
         key: 'events.archives',


### PR DESCRIPTION
Description:
On the navigation bar, the links to Fall Hacks and Mountain Madness were pointing to the `new.sfucsss.org` links.

Root cause:
The URL they were using was wrong

Fix:
Changed the URLs to the proper versions.
