### PR TITLE
Fix: Frosh 2025 Room Finder link

### DIFF
--- a/public/frosh/2025/index.html
+++ b/public/frosh/2025/index.html
@@ -531,8 +531,9 @@
             <h3>I can't find a room!</h3>
             <p>
               SFU provides a very handy tool called the
-              <a href="roomfinder.sfu.ca/apps/sfuroomfinder_web" target="_blank">Room Finder</a>.
-              Simply input the room number (e.g. ASB 9703), and it will highlight the room on an
+              <a href="https://roomfinder.sfu.ca/apps/sfuroomfinder_web" target="_blank"
+                >Room Finder</a
+              >. Simply input the room number (e.g. ASB 9703), and it will highlight the room on an
               interactive campus map. This works for the Burnaby, Surrey, and Vancouver campuses.
             </p>
           </div>


### PR DESCRIPTION
Description:
The Room Finder link in FAQ > Room Finder had the wrong URL.

# FOR BUGS
Root cause:
The href had a relative URL, instead of an exact URL.

Fix:
Changed the URL to use an exact URL.
