### PR TITLE
Fix: update deploy script and sync package-lock

### DIFF
--- a/.github/workflows/deploy-to-build.yml
+++ b/.github/workflows/deploy-to-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js, install dependencies and build
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
       - run: npm ci
       - run: npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -874,6 +874,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",


### PR DESCRIPTION
closes #

Root cause:
`package-lock.json` file was not synced with `package.json`

Fix:
Ran `npm install` locally and committed the package-lock file generated
